### PR TITLE
task-238-add-starting-number-setting-for-invoices-and-credit-notes

### DIFF
--- a/modules/billing/Models/CreditNote.php
+++ b/modules/billing/Models/CreditNote.php
@@ -80,7 +80,11 @@ class CreditNote extends Model
                         ->orderBy('identifier_number', 'desc')
                         ->first();
 
-                    $nextNumber = $lastOffer ? $lastOffer->identifier_number + 1 : 1;
+                    $start = Meta::getValue('tenant_billing_details')['credit_note_start_number'] ?? 1;
+
+                    $nextNumber = $lastOffer
+                        ? max($start, $lastOffer->identifier_number + 1)
+                        : $start;
 
                     $credit_note->identifier_number = $nextNumber;
                     $credit_note->identifier = sprintf('%d/%03d', $year, $nextNumber);

--- a/modules/billing/Models/Estimate.php
+++ b/modules/billing/Models/Estimate.php
@@ -89,7 +89,11 @@ class Estimate extends Model
                         ->orderBy('identifier_number', 'desc')
                         ->first();
 
-                    $nextNumber = $lastOffer ? $lastOffer->identifier_number + 1 : 1;
+                    $start = Meta::getValue('tenant_billing_details')['estimate_start_number'] ?? 1;
+
+                    $nextNumber = $lastOffer
+                        ? max($start, $lastOffer->identifier_number + 1)
+                        : $start;
 
                     $estimate->identifier_number = $nextNumber;
                     $estimate->identifier = sprintf('%d/%03d', $year, $nextNumber);

--- a/modules/billing/Models/Invoice.php
+++ b/modules/billing/Models/Invoice.php
@@ -89,16 +89,19 @@ class Invoice extends Model
                         ->orderBy('identifier_number', 'desc')
                         ->first();
 
-                    $nextNumber = $lastOffer ? $lastOffer->identifier_number + 1 : 1;
+                    $start = Meta::getValue('tenant_billing_details')['invoice_start_number'] ?? 1;
+
+                    $nextNumber = $lastOffer
+                        ? max($start, $lastOffer->identifier_number + 1)
+                        : $start;
 
                     $invoice->identifier_number = $nextNumber;
                     $invoice->identifier = sprintf('%d/%03d', $year, $nextNumber);
                 }
 
-                if(empty($invoice->structured_communication)){
+                if (empty($invoice->structured_communication)) {
                     $invoice->structured_communication = \Diji\Billing\Helpers\Invoice::generateStructuredCommunication($invoice->identifier_number);
                 }
-
             }
 
             if ($invoice->isDirty('date')) {

--- a/modules/billing/Models/SelfInvoice.php
+++ b/modules/billing/Models/SelfInvoice.php
@@ -82,21 +82,24 @@ class SelfInvoice extends Model
                 if (empty($invoice->identifier_number)) {
                     $year = now()->year;
 
-                    $lastOffer = self::whereYear('date', $year)
+                    $lastInvoice = self::whereYear('date', $year)
                         ->whereNotNull('identifier_number')
                         ->orderBy('identifier_number', 'desc')
                         ->first();
 
-                    $nextNumber = $lastOffer ? $lastOffer->identifier_number + 1 : 1;
+                    $start = Meta::getValue('tenant_billing_details')['self_invoice_start_number'] ?? 1;
+
+                    $nextNumber = $lastInvoice
+                        ? max($start, $lastInvoice->identifier_number + 1)
+                        : $start;
 
                     $invoice->identifier_number = $nextNumber;
                     $invoice->identifier = sprintf('%d/%03d', $year, $nextNumber);
                 }
 
-                if(empty($invoice->structured_communication)){
+                if (empty($invoice->structured_communication)) {
                     $invoice->structured_communication = \Diji\Billing\Helpers\Invoice::generateStructuredCommunication($invoice->identifier_number);
                 }
-
             }
         });
 


### PR DESCRIPTION
Dans les différents modèles du module de facturation, il faudra remplacer $start = Meta::getValue par quelque chose comme Tenants->settings après tous les merges.